### PR TITLE
Update lastfm macros to include not exclude

### DIFF
--- a/default/macros.conf
+++ b/default/macros.conf
@@ -7,11 +7,11 @@ definition = inputlookup concerthistoryparse.csv | eval artist = headliner
 iseval = 0
 
 [lastfm]
-definition = index=music sourcetype!="itunes_xml" sourcetype!="songkick" |dedup uts
+definition = index=music sourcetype="lastfm*" |dedup uts
 iseval = 0
 
 [lastfm_earliest]
-definition = index=music sourcetype!="itunes_xml" |dedup uts | lookup earliestlistens.csv artist OUTPUT year as earliestyear
+definition = index=music sourcetype="lastfm*" |dedup uts | lookup earliestlistens.csv artist OUTPUT year as earliestyear
 iseval = 0
 
 [makeartist]
@@ -19,11 +19,11 @@ definition = inputlookup concerts.csv | makemv delim="," artist | mvexpand artis
 iseval = 0
 
 [lastfm_earliest_mbid]
-definition = index=music sourcetype!="itunes_xml" |dedup uts | lookup earliestlistensmbid.csv artist_mbid OUTPUT year as earliestyear
+definition = index=music sourcetype="lastfm*" |dedup uts | lookup earliestlistensmbid.csv artist_mbid OUTPUT year as earliestyear
 iseval = 0
 
 [lastfm_earlier]
-definition = index=music sourcetype!="itunes_xml" |dedup uts | lookup earliesttracklistens.csv track_name OUTPUT earliestlisten as earliestlisten
+definition = index=music sourcetype="lastfm*" |dedup uts | lookup earliesttracklistens.csv track_name OUTPUT earliestlisten as earliestlisten
 iseval = 0
 
 [drop_dataset(1)]


### PR DESCRIPTION
Updating macro definitions for lastfm sourcetypes to explicitly specify the lastfm sourcetypes rather than catching them by eliminating other sourcetypes. This is important as I continue to add new data sources.